### PR TITLE
Match APU buffering to CPU ticks

### DIFF
--- a/pkg/apu/channel.go
+++ b/pkg/apu/channel.go
@@ -1,0 +1,126 @@
+package apu
+
+import "math"
+
+// NewChannel returns a new sound channel using a sampling function.
+func NewChannel() *Channel {
+	return &Channel{}
+}
+
+// Channel represents one of four Gameboy sound channels.
+type Channel struct {
+	frequency float64
+	generator WaveGenerator
+	time      float64
+	amplitude float64
+
+	// Duration in samples
+	duration int
+	length int
+
+	envelopeVolume int
+	envelopeTime       int
+	envelopeSteps      int
+	envelopeStepsInit  int
+	envelopeSamples    int
+	envelopeIncreasing bool
+
+	sweepTime     float64
+	sweepStepLen  byte
+	sweepSteps    byte
+	sweepStep     byte
+	sweepIncrease bool
+
+	onL bool
+	onR bool
+	// Debug flag to turn off sound output
+	debugOff bool
+}
+
+// Sample returns a single sample for streaming the sound output. Each sample
+// will increase the internal timer based on the global sample rate.
+func (chn *Channel) Sample() (outputL, outputR uint16) {
+	var output uint16
+	step := chn.frequency * twoPi / float64(sampleRate)
+	chn.time += step
+	if chn.shouldPlay() {
+		// Take the sample value from the generator
+		if !chn.debugOff {
+			output = uint16(float64(chn.generator(chn.time)) * chn.amplitude)
+		}
+		if chn.duration > 0 {
+			chn.duration--
+		}
+	}
+	chn.updateEnvelope()
+	chn.updateSweep()
+	if chn.onL {
+		outputL = output
+	}
+	if chn.onR {
+		outputR = output
+	}
+	return
+}
+
+// Reset the channel to some default variables for the sweep, amplitude,
+// envelope and duration.
+func (chn *Channel) Reset(duration int) {
+	chn.amplitude = 1
+	chn.envelopeTime = 0
+	chn.sweepTime = 0
+	chn.sweepStep = 0
+	chn.duration = duration
+}
+
+// Returns if the channel should be playing or not.
+func (chn *Channel) shouldPlay() bool {
+	return (chn.duration == -1 || chn.duration > 0) &&
+		chn.generator != nil && chn.envelopeStepsInit > 0
+}
+
+// Update the state of the channels envelope.
+func (chn *Channel) updateEnvelope() {
+	if chn.envelopeSamples > 0 {
+		chn.envelopeTime += 1
+		if chn.envelopeSteps > 0 && chn.envelopeTime >= chn.envelopeSamples {
+			chn.envelopeTime -= chn.envelopeSamples
+			chn.envelopeSteps--
+			if chn.envelopeSteps == 0 {
+				chn.amplitude = 0
+			} else if chn.envelopeIncreasing {
+				chn.amplitude = 1 - float64(chn.envelopeSteps)/float64(chn.envelopeStepsInit)
+			} else {
+				chn.amplitude = float64(chn.envelopeSteps) / float64(chn.envelopeStepsInit)
+			}
+		}
+	}
+}
+
+var sweepTimes = map[byte]float64{
+	1: 7.8 / 1000,
+	2: 15.6 / 1000,
+	3: 23.4 / 1000,
+	4: 31.3 / 1000,
+	5: 39.1 / 1000,
+	6: 46.9 / 1000,
+	7: 54.7 / 1000,
+}
+
+// Update the state of the channels sweep.
+func (chn *Channel) updateSweep() {
+	if chn.sweepStep < chn.sweepSteps {
+		t := sweepTimes[chn.sweepStepLen]
+		chn.sweepTime += perSample
+		if chn.sweepTime > t {
+			chn.sweepTime -= t
+			chn.sweepStep += 1
+
+			if chn.sweepIncrease {
+				chn.frequency += chn.frequency / math.Pow(2, float64(chn.sweepStep))
+			} else {
+				chn.frequency -= chn.frequency / math.Pow(2, float64(chn.sweepStep))
+			}
+		}
+	}
+}

--- a/pkg/apu/channel.go
+++ b/pkg/apu/channel.go
@@ -16,9 +16,9 @@ type Channel struct {
 
 	// Duration in samples
 	duration int
-	length int
+	length   int
 
-	envelopeVolume int
+	envelopeVolume     int
 	envelopeTime       int
 	envelopeSteps      int
 	envelopeStepsInit  int

--- a/pkg/apu/waves.go
+++ b/pkg/apu/waves.go
@@ -1,0 +1,44 @@
+package apu
+
+import (
+	"math"
+	"math/rand"
+)
+
+// WaveGenerator is a function which can be used for generating waveform
+// samples for different channels.
+type WaveGenerator func(t float64) byte
+
+// Square returns a square wave generator with a given mod. This is used
+// for channels 1 and 2.
+func Square(mod float64) WaveGenerator {
+	return func(t float64) byte {
+		if math.Sin(t) <= mod {
+			return 0xFF
+		}
+		return 0
+	}
+}
+
+// Waveform returns a wave generator for some waveform ram. This is used
+// by channel 3.
+func Waveform(ram func(i int) byte) WaveGenerator {
+	return func(t float64) byte {
+		idx := int(math.Floor(t/twoPi*32)) % 0x20
+		return ram(idx)
+	}
+}
+
+// Noise returns a wave generator for a noise channel. This is used by
+// channel 4.
+func Noise() WaveGenerator {
+	var last float64
+	var val byte
+	return func(t float64) byte {
+		if t-last > twoPi {
+			last = t
+			val = byte(rand.Intn(2)) * 0xFF
+		}
+		return val
+	}
+}

--- a/pkg/gb/gameboy.go
+++ b/pkg/gb/gameboy.go
@@ -51,7 +51,7 @@ type Gameboy struct {
 	mainInst [0x100]func()
 	cbInst   [0x100]func()
 
-	// Mask of the currenly pressed buttons.
+	// Mask of the currently pressed buttons.
 	inputMask byte
 
 	// Flag if the game is running in cgb mode. For this to be true the game
@@ -87,6 +87,8 @@ func (gb *Gameboy) Update() int {
 		gb.updateGraphics(cyclesOp)
 		gb.updateTimers(cyclesOp)
 		cycles += gb.doInterrupts()
+
+		gb.Sound.Buffer(cyclesOp, gb.getSpeed())
 	}
 	return cycles
 }
@@ -104,6 +106,10 @@ func (gb *Gameboy) IsPaused() bool {
 // ToggleSoundChannel toggles a sound channel for debugging.
 func (gb *Gameboy) ToggleSoundChannel(channel int) {
 	gb.Sound.ToggleSoundChannel(channel)
+}
+
+func (gb *Gameboy) SoundString() {
+	gb.Sound.LogSoundState()
 }
 
 // BGMapString returns a string of the values in the background map.

--- a/pkg/gbio/iopixel/pixels.go
+++ b/pkg/gbio/iopixel/pixels.go
@@ -168,6 +168,9 @@ var extraKeyMap = map[pixelgl.Button]func(*PixelsIOBinding){
 	pixelgl.Key0: func(mon *PixelsIOBinding) {
 		mon.Gameboy.ToggleSoundChannel(4)
 	},
+	pixelgl.KeyMinus: func(mon *PixelsIOBinding) {
+		mon.Gameboy.SoundString()
+	},
 
 	// Fullscreen toggle
 	pixelgl.KeyF: func(mon *PixelsIOBinding) {


### PR DESCRIPTION
Previously the APU ran completely without knowledge of how fast the CPU was running. This PR makes it so that the APU is buffered with the number of CPU ticks. This fixes issues with complex sounds such as in the opening of `Pokemon Yellow`.