### PR TITLE
Improve performance on commonly accessed memory reads

### DIFF
--- a/pkg/gb/gameboy.go
+++ b/pkg/gb/gameboy.go
@@ -146,9 +146,9 @@ func (gb *Gameboy) updateTimers(cycles int) {
 		freq := gb.getClockFreqCount()
 		for gb.timerCounter >= freq {
 			gb.timerCounter -= freq
-			tima := gb.Memory.Read(TIMA)
+			tima := gb.Memory.HighRAM[0x05] /* TIMA */
 			if tima == 0xFF {
-				gb.Memory.HighRAM[TIMA-0xFF00] = gb.Memory.Read(TMA)
+				gb.Memory.HighRAM[TIMA-0xFF00] = gb.Memory.HighRAM[0x06] /* TMA */
 				gb.requestInterrupt(2)
 			} else {
 				gb.Memory.HighRAM[TIMA-0xFF00] = tima + 1
@@ -158,11 +158,11 @@ func (gb *Gameboy) updateTimers(cycles int) {
 }
 
 func (gb *Gameboy) isClockEnabled() bool {
-	return bits.Test(gb.Memory.Read(TAC), 2)
+	return bits.Test(gb.Memory.HighRAM[0x07] /* TAC */, 2)
 }
 
 func (gb *Gameboy) getClockFreq() byte {
-	return gb.Memory.Read(TAC) & 0x3
+	return gb.Memory.HighRAM[0x07] /* TAC */ & 0x3
 }
 
 func (gb *Gameboy) getClockFreqCount() int {
@@ -192,7 +192,7 @@ func (gb *Gameboy) dividerRegister(cycles int) {
 
 // Request the Gameboy to perform an interrupt.
 func (gb *Gameboy) requestInterrupt(interrupt byte) {
-	req := gb.Memory.ReadHighRam(0xFF0F)
+	req := gb.Memory.HighRAM[0x0F] | 0xE0
 	req = bits.Set(req, interrupt)
 	gb.Memory.Write(0xFF0F, req)
 }
@@ -207,8 +207,8 @@ func (gb *Gameboy) doInterrupts() (cycles int) {
 		return 0
 	}
 
-	req := gb.Memory.ReadHighRam(0xFF0F)
-	enabled := gb.Memory.ReadHighRam(0xFFFF)
+	req := gb.Memory.HighRAM[0x0F] | 0xE0
+	enabled := gb.Memory.HighRAM[0xFF]
 
 	if req > 0 {
 		var i byte

--- a/pkg/gb/ppu.go
+++ b/pkg/gb/ppu.go
@@ -49,7 +49,7 @@ const (
 
 // Set the status of the LCD based on the current state of memory.
 func (gb *Gameboy) setLCDStatus() {
-	status := gb.Memory.ReadHighRam(0xFF41)
+	status := gb.Memory.HighRAM[0x41]
 
 	if !gb.isLCDEnabled() {
 		// set the screen to white
@@ -67,7 +67,7 @@ func (gb *Gameboy) setLCDStatus() {
 	}
 	gb.screenCleared = false
 
-	currentLine := gb.Memory.ReadHighRam(0xFF44)
+	currentLine := gb.Memory.HighRAM[0x44]
 	currentMode := status & 0x3
 
 	var mode byte
@@ -109,7 +109,7 @@ func (gb *Gameboy) setLCDStatus() {
 	}
 
 	// Check if LYC == LY (coincidence flag)
-	if currentLine == gb.Memory.ReadHighRam(0xFF45) {
+	if currentLine == gb.Memory.HighRAM[0x45] {
 		status = bits.Set(status, 2)
 		// If enabled request an interrupt for this
 		if bits.Test(status, 6) {
@@ -124,7 +124,7 @@ func (gb *Gameboy) setLCDStatus() {
 
 // Checks if the LCD is enabled by examining 0xFF40.
 func (gb *Gameboy) isLCDEnabled() bool {
-	return bits.Test(gb.Memory.ReadHighRam(LCDC), 7)
+	return bits.Test(gb.Memory.HighRAM[0x40], 7)
 }
 
 // Draw a single scanline to the graphics output.


### PR DESCRIPTION
In some highly used timer, clock and PPU methods RAM access was using the memory functions which come with a large overhead. Directly accessing the memory in these special cases results in significant CPU usage improvement.